### PR TITLE
Fix the problem 'make' doesn't init submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ DEPS += $(DCURL_LIB)
 
 all: $(DEPS)
 
+.PHONY: $(DCURL_LIB)
 $(DCURL_LIB): $(DCURL_DIR)
 	 git submodule update --init $^
 	$(MAKE) -C $^ config


### PR DESCRIPTION
Because the target `DCURL_LIB` in the Makefile is the latest, hence the `git submodule` scripts won't be triggered.