### PR TITLE
IOTA Palantír Messaging (IPM) implementation

### DIFF
--- a/extensions/tangleid/main.py
+++ b/extensions/tangleid/main.py
@@ -1,7 +1,7 @@
 import time
 import json
 from swarm_node import get_tips, send_transfer, \
-    find_transactions_by_tag, get_txn_msg
+    find_transactions_by_tag, get_txn_msg, find_transactions_by_address
 
 address = "BXEOYAONFPBGKEUQZDUZZZODHWJDWHEOYY9AENYF9VNLXZHXBOODCOTYXW9MGGINTEJPLK9AGOPTPODVX"
 
@@ -39,6 +39,9 @@ def load(data):
     elif request_data['command'] == "new_group":
         result = new_group(data)
         return result
+    elif request_data['command'] == "get_all_claims_in_channel":
+        result = get_all_claims_in_channel(data)
+        return result
 
 
 def new_claim(data):
@@ -49,7 +52,10 @@ def new_claim(data):
 
     # Set output transaction
     tag = data['uuid'] + "C"
-    response = send_transfer(tag, json.dumps(data), address, 0, dict_tips, debug=0)
+    if 'addr' in data:
+        response = send_transfer(tag, json.dumps(data), data['addr'], 0, dict_tips, debug=0)
+    else:
+        response = send_transfer(tag, json.dumps(data), address, 0, dict_tips, debug=0)
 
     return str(response)
 
@@ -175,3 +181,20 @@ def new_group(data):
     response = send_transfer(tag, json.dumps(data), address, 0, dict_tips, debug=0)
 
     return str(response)
+
+def get_all_claims_in_channel(data):
+    data = json.loads(data)
+
+    address = data['channel'].ljust(81,'9')
+    list_claims = find_transactions_by_address(address)
+
+    if len(list_claims) == 0:
+        return []
+
+    list_claims = list_claims['hashes']
+
+    list_output = []
+    for obj in list_claims:
+        list_output.append(str(obj))
+
+    return str(list_output)

--- a/swarm_node.py
+++ b/swarm_node.py
@@ -207,3 +207,12 @@ def get_txn_msg(data):
         return ""
 
     return message
+
+def find_transactions_by_address(data):
+
+    try:
+        list_result = api.find_transactions(addresses=[data])
+    except BaseException:
+        return []
+
+    return list_result

--- a/tests/tangleid/get_all_claims_in_channel.sh
+++ b/tests/tangleid/get_all_claims_in_channel.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source tests/common.sh
+
+POST '{"extension":"tangleid","command":"get_all_claims_in_channel","channel": "JXWDGDDSAVZVJ9LAK9N9JVKLMQ"}'

--- a/tests/tangleid/new_claim_ipm.sh
+++ b/tests/tangleid/new_claim_ipm.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source tests/common.sh
+
+POST '{"extension":"tangleid", "command":"new_claim","uuid": "V9TCFLAOGGTAQATTJBLABAG9WY", "addr":"IWHR9VJRGGTAQATTJHIJNW9OKJ","next_addr":"S9FHEJVOWHG9SHGJWNRKVNWJRX", "msg":"TestingMessage"}'


### PR DESCRIPTION
This is a spike to implement IOTA Palantír Messaging (IPM)[1] in TangleID new_claim[2] and get_all_claims_in_channel[3] API commands. Just add the key "addr" and "next_addr" keys in new_claim API request body for enabling the function and use get_all_claims_in_channel to query all claims in one channel, refer the API mamual[2][3] or test script file "tests/tangleid/new_claim_ipm.sh",  "tests/tangleid/get_all_claims_in_channel.sh" for detail.
The other hand, one complete workflow demonstration could be found on here[4].

[1] https://blog.florence.chat/introducing-iota-palant%C3%ADr-messaging-ipm-c599ed6d2191
[2] https://hackmd.io/s/HJyzQvF1z
[3] https://hackmd.io/s/ry-8g8nNQ
[4] https://github.com/yillkid/TangleID-IPM-sample