### PR TITLE
Fetch the latest commit from dcurl upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "deps/dcurl"]
 	path = deps/dcurl
 	url = https://github.com/DLTcollab/dcurl
+	branch = dev

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: $(DEPS)
 
 .PHONY: $(DCURL_LIB)
 $(DCURL_LIB): $(DCURL_DIR)
-	 git submodule update --init $^
+	git submodule update --remote $^
 	$(MAKE) -C $^ config
 	@echo
 	$(info Modify $^/build/local.mk for your environments.)


### PR DESCRIPTION
Why does the original `make check` checkout the bizarre version rather than the latest one?

```
cwei@creeper ~/w/iota_swarm_like_node> make check
Modify deps/dcurl/build/local.mk for your environments.
git submodule update --init deps/dcurl
Submodule 'deps/dcurl' (https://github.com/DLTcollab/dcurl) registered for path 'deps/dcurl'
Cloning into 'deps/dcurl'...
remote: Counting objects: 1138, done.
remote: Compressing objects: 100% (66/66), done.
remote: Total 1138 (delta 122), reused 151 (delta 108), pack-reused 964
Receiving objects: 100% (1138/1138), 398.38 KiB | 413.00 KiB/s, done.
Resolving deltas: 100% (712/712), done.
Checking connectivity... done.
Submodule path 'deps/dcurl': checked out 'e863d28feb032273be43ea199dbdf24f42e78d2e'
```