### PR TITLE
Switch test suite to Python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ all: $(DEPS)
 
 .PHONY: $(DCURL_LIB)
 $(DCURL_LIB): $(DCURL_DIR)
+	git submodule update --init $^
 	git submodule update --remote $^
 	$(MAKE) -C $^ config
 	@echo
@@ -32,3 +33,5 @@ clean:
 distclean: clean
 	$(RM) -r $(DCURL_DIR)
 	git checkout $(DCURL_DIR)
+
+include mk/python.mk

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ TESTS += $(wildcard tests/tangleid/*.sh)
 check: server.py $(DCURL_LIB)
 	@ TMP_PID=`mktemp /tmp/server_pid.XXXXXX`; \
 	echo "Running test suite..." ; \
-	( python $^ & echo $$! > $${TMP_PID} ); \
+	( python3 $^ & echo $$! > $${TMP_PID} ); \
 	sleep 3 ; \
 	for i in $(TESTS); do \
 	    ( echo "\n\n==[ $$i ]==\n"; $$i || kill -9 `cat $${TMP_PID}` ) \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# IOTA Swarm Node
+# IOTA Swarm Node [![](https://img.shields.io/badge/python-3.5-blue.svg)](https://www.python.org/download/releases/3.5.0/)
 
 ## Summary
 

--- a/mk/python.mk
+++ b/mk/python.mk
@@ -1,0 +1,14 @@
+PYTHON = python3
+PYTHON := $(shell which $(PYTHON))
+ifndef PYTHON
+$(error "python3 is required.")
+endif
+
+# check "iota" module in Python installation
+PY_CHECK_MOD_IOTA := $(shell $(PYTHON) -c "import iota" 2>/dev/null && \
+                       echo 1 || echo 0)
+ifeq ("$(PY_CHECK_MOD_IOTA)","1")
+    py_prepare_cmd = $(Q)cat $< >> $@
+else 
+    py_prepare_cmd = $(warning "skip $@ because PyIOTA is not installed.")
+endif

--- a/tests/generate_address.py
+++ b/tests/generate_address.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from service import generate_address
 
 HOST = 'http://127.0.0.1'

--- a/tests/get_tips.py
+++ b/tests/get_tips.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from service import get_tips
 
 TIPS_TYPE_IRI_REQULAR_ALGORITHM = 0

--- a/tests/send_transfer.py
+++ b/tests/send_transfer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from service import send_transfer
 
 TIPS_TYPE_IRI_REQULAR_ALGORITHM = 0

--- a/tests/service.py
+++ b/tests/service.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import time
 import json
 


### PR DESCRIPTION
Since swarm-node supports Python3 already, it's necessary to upgrade for all test suites