### PR TITLE
Integrate Travis CI service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "3.6"
+install:
+  - pip install -r requirements.txt
+
+script:
+  - make check


### PR DESCRIPTION
To avoid the potential conflicts, integrate Travis CI to build the
code and run the test cases when code base changes.